### PR TITLE
update location info use the city name

### DIFF
--- a/src/main/java/com/plugin/awesomejava/Location/GetCurrentRegion.java
+++ b/src/main/java/com/plugin/awesomejava/Location/GetCurrentRegion.java
@@ -33,7 +33,7 @@ public class GetCurrentRegion {
              if (locationServices == null) {
                 return entry;
             }
-            String City = locationServices.countryName;
+            String City = locationServices.city;
             String CountryCode = locationServices.countryCode;
 
             entry = new FeedEntry();


### PR DESCRIPTION
The GetCurrentRegion class was setting City to countryName which in turn meant for very inaccurate weather data unless you live in the center of your country.